### PR TITLE
Negative Payments

### DIFF
--- a/app/ninja/repositories/PaymentRepository.php
+++ b/app/ninja/repositories/PaymentRepository.php
@@ -68,7 +68,7 @@ class PaymentRepository
         $rules = array(
             'client' => 'required',
             'invoice' => 'required',
-            'amount' => 'required|positive',
+            'amount' => 'required',
         );
 
         if ($input['payment_type_id'] == PAYMENT_TYPE_CREDIT) {


### PR DESCRIPTION
Needed when making an invoice with a negative amount.
The usecase for this is that in denmark you are not allowed to change an invoice once
it has been filed.
So to change an invoice or cancel it, it is required to create a creditnote.
The system allows this but does not let you enter a negative payment for an invoice(creditnote in this case)
which is a mistake.