### PR TITLE
Updated barryvdh/laravel-debugbar version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"patricktalmadge/bootstrapper": "4.1.x",
 		"zizaco/confide": "3.1.x",
 		"anahkiasen/former": "3.4.x",
-		"barryvdh/laravel-debugbar": "dev-master",
+		"barryvdh/laravel-debugbar": "~1.8",
 		"chumper/datatable": "2.x",
 		"omnipay/omnipay": "~2.0",
 		"intervention/image": "1.x",


### PR DESCRIPTION
Laravel 4 must use 1.8 version. dev-master is for Laravel 5