### PR TITLE
Public payment page white label issue

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -325,6 +325,7 @@ class PaymentController extends BaseController
             'countries' => Cache::get('countries'),
             'currencyId' => $client->currency_id,
             'account' => $client->account,
+            'hideLogo' => $account->isWhiteLabel(),
         ];
 
         return View::make('payments.payment', $data);


### PR DESCRIPTION
Currently when an account is in white-label mode, the logo is not removed from the public credit card payment page. All the other public pages work just fine, but `PaymentController@show_payment` seemed to be missing this variable. 

Not sure if this is currently working as intended or not (but please feel free to close this without merging if the intent is indeed for the logo to always be shown on the client credit card payment page even if white-labeled).