### PR TITLE
Fixed template error on Advanced Settings / Invoice Design

### DIFF
--- a/resources/views/accounts/invoice_design.blade.php
+++ b/resources/views/accounts/invoice_design.blade.php
@@ -85,9 +85,11 @@
       {!! Former::populate($account) !!}
       {!! Former::populateField('hide_quantity', intval($account->hide_quantity)) !!}
       {!! Former::populateField('hide_paid_to_date', intval($account->hide_paid_to_date)) !!}
-      @foreach ($invoiceLabels as $field => $value)
-        {!! Former::populateField("labels_{$field}", $value) !!}
-      @endforeach      
+      @if ($invoiceLabels)
+        @foreach ($invoiceLabels as $field => $value)
+          {!! Former::populateField("labels_{$field}", $value) !!}
+        @endforeach
+      @endif
 
     <div class="panel panel-default">
       <div class="panel-heading">


### PR DESCRIPTION
# Problem
If the invoice labels were not yet defined, an invalid argument error was being
thrown on page render. Thusly, preventing the admin from being able to initialize the custom invoice labels. 

# Solution
Wrapped the foreach loop in a conditional. 