### PR TITLE
New account gateways not saving

### DIFF
--- a/app/Http/Controllers/AccountGatewayController.php
+++ b/app/Http/Controllers/AccountGatewayController.php
@@ -186,7 +186,7 @@ class AccountGatewayController extends BaseController
             $gatewayId = GATEWAY_PAYPAL_EXPRESS;
         } elseif ($paymentType == PAYMENT_TYPE_BITCOIN) {
             $gatewayId = GATEWAY_BITPAY;
-        } elseif ($paymentType = PAYMENT_TYPE_DWOLLA) {
+        } elseif ($paymentType == PAYMENT_TYPE_DWOLLA) {
             $gatewayId = GATEWAY_DWOLLA;
         }
 


### PR DESCRIPTION
Noticed a bug when setting up things locally.  This prevented new account gateways from being saved in the DB.