### PR TITLE
Add payment link variables in invoice emails

### DIFF
--- a/app/Ninja/Mailers/ContactMailer.php
+++ b/app/Ninja/Mailers/ContactMailer.php
@@ -2,6 +2,7 @@
 
 use Utils;
 use Event;
+use URL;
 
 use App\Models\Invoice;
 use App\Models\Payment;
@@ -40,6 +41,18 @@ class ContactMailer extends Mailer
                 '$contact' => $invitation->contact->getDisplayName(),
                 '$amount' => $invoiceAmount
             ];
+
+            // Add variables for available payment types
+            foreach([PAYMENT_TYPE_CREDIT_CARD, PAYMENT_TYPE_PAYPAL, PAYMENT_TYPE_BITCOIN] as $type) {
+                if ($invoice->account->getGatewayByType($type)) {
+
+                    // Changes "PAYMENT_TYPE_CREDIT_CARD" to "$credit_card_link"
+                    $gateway_slug = '$'.strtolower(str_replace('PAYMENT_TYPE_', '', $type)).'_link';
+
+                    $variables[$gateway_slug] = URL::to("/payment/{$invitation->invitation_key}/{$type}");
+
+                }
+            }
 
             $data['body'] = str_replace(array_keys($variables), array_values($variables), $emailTemplate);
             $data['link'] = $invitation->getLink();

--- a/resources/views/accounts/email_templates.blade.php
+++ b/resources/views/accounts/email_templates.blade.php
@@ -108,7 +108,23 @@
             }
 
             keys = ['footer', 'account', 'client', 'amount', 'link', 'contact'];
-            vals = [{!! json_encode($emailFooter) !!}, '{!! Auth::user()->account->getDisplayName() !!}', 'Client Name', formatMoney(100), '{!! NINJA_WEB_URL !!}', 'Contact Name']
+            vals = [{!! json_encode($emailFooter) !!}, '{!! Auth::user()->account->getDisplayName() !!}', 'Client Name', formatMoney(100), '{!! NINJA_WEB_URL !!}', 'Contact Name'];
+
+            // Add any available payment method links
+            <?php
+            foreach([PAYMENT_TYPE_CREDIT_CARD, PAYMENT_TYPE_PAYPAL, PAYMENT_TYPE_BITCOIN] as $type) {
+                if (Auth::user()->account->getGatewayByType($type)) {
+
+                    // Changes "PAYMENT_TYPE_CREDIT_CARD" to "credit_card"
+                    $gateway_slug = strtolower(str_replace('PAYMENT_TYPE_', '', $type)).'_link';
+
+                    echo "keys.push('$gateway_slug'); ";
+                    echo "vals.push('".URL::to("/payment/xxxxxx/{$type}")."'); ";
+                    echo "\n";
+                    
+                }
+            }
+            ?>
 
             for (var i=0; i<keys.length; i++) {
                 var regExp = new RegExp('\\$'+keys[i], 'g');


### PR DESCRIPTION
Here is one possible implementation of the payment links for emails for #321

With this update, the additional email template variables include:

Variable | Service
---|---
$paypal_link | PayPal
$credit_card_link | Credit Card
$bitcoin_link | Bitcoin

The variables are only available/parsed if the payment gateway has been set up. I wasn't able to test PayPal or Bitcoin since I don't have those gateways, but I guessed that the payment links for those gateways followed the same format. 

### Still needed:

Add something to the template editor UI to tell users that these new variables are available. Right now there is no way for the user to know that the variable is available. Maybe there could be a list of the available variables accessible somewhere on the edit template page. 