### PR TITLE
Reimplemented customer email templating in laravel5 branch.

### DIFF
--- a/app/Libraries/Utils.php
+++ b/app/Libraries/Utils.php
@@ -677,4 +677,29 @@ class Utils
 
         fwrite($output, "\n");
     }
+    
+    public static function stringToObjectResolution($baseObject, $rawPath)
+    {
+        $val = '';
+        
+        if (!is_object($baseObject)) {
+          return $val;
+        }
+        
+        $path = preg_split('/->/', $rawPath);
+        $node = $baseObject;
+        
+        while (($prop = array_shift($path)) !== null) {
+            if (property_exists($node, $prop)) {
+                $val = $node->$prop;
+                $node = $node->$prop;
+            } else if (is_object($node) && isset($node->$prop)) {
+                $node = $node->{$prop};
+            } else if ( method_exists($node, $prop)) {
+                $val = call_user_func(array($node, $prop));
+            }
+        }
+        
+        return $val;
+    }
 }

--- a/app/Ninja/Mailers/ContactMailer.php
+++ b/app/Ninja/Mailers/ContactMailer.php
@@ -23,6 +23,8 @@ class ContactMailer extends Mailer
         $emailTemplate = $invoice->account->getEmailTemplate($entityType);
         $invoiceAmount = Utils::formatMoney($invoice->getRequestedAmount(), $invoice->client->getCurrencyId());
 
+        $this->initClosure($invoice);
+
         foreach ($invoice->invitations as $invitation) {
             if (!$invitation->user || !$invitation->user->email || $invitation->user->trashed()) {
                 return false;
@@ -40,7 +42,8 @@ class ContactMailer extends Mailer
                 '$client' => $invoice->client->getDisplayName(),
                 '$account' => $accountName,
                 '$contact' => $invitation->contact->getDisplayName(),
-                '$amount' => $invoiceAmount
+                '$amount' => $invoiceAmount,
+                '$advancedRawInvoice->' => '$'
             ];
 
             // Add variables for available payment types
@@ -49,6 +52,7 @@ class ContactMailer extends Mailer
             }
 
             $data['body'] = str_replace(array_keys($variables), array_values($variables), $emailTemplate);
+            $data['body'] = preg_replace_callback('/\{\{\$?(.*)\}\}/', $this->advancedTemplateHandler, $data['body']);
             $data['link'] = $invitation->getLink();
             $data['entityType'] = $entityType;
             $data['invoice_id'] = $invoice->id;
@@ -122,5 +126,23 @@ class ContactMailer extends Mailer
         ];
         
         $this->sendTo($email, CONTACT_EMAIL, CONTACT_NAME, $subject, $view, $data);
+    }
+
+    private function initClosure($object)
+    {
+        $this->advancedTemplateHandler = function($match) use ($object) {
+            for ($i = 1; $i < count($match); $i++) {
+                $blobConversion = $match[$i];
+
+                if (isset($$blobConversion)) {
+                    return $$blobConversion;
+                } else if (preg_match('/trans\(([\w\.]+)\)/', $blobConversion, $regexTranslation)) {
+                    return trans($regexTranslation[1]);
+                } else if (strpos($blobConversion, '->') !== false) {
+                    return Utils::stringToObjectResolution($object, $blobConversion);
+                }
+
+            }
+        };
     }
 }


### PR DESCRIPTION
Original Issue: Enhanced invoice email templating. #256 

I have closed the original issue because it diverged to far from the current laravel5 codebase.
The current issue is the implementation of the old feature ready to be merged.

----------------------------

Added the ability to use data from raw invoice with e.g
{{$advancedRawInvoice->client->getDisplayName}}

Brought back translation support with e.g
{{trans(texts.custom_email_translation)}}
