### PR TITLE
Fixed timezone DST issues in timelog

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,6 +67,7 @@ module.exports = function(grunt) {
           'public/vendor/spectrum/spectrum.js',
           'public/vendor/jspdf/dist/jspdf.min.js',
           'public/vendor/moment/min/moment.min.js',
+          'public/vendor/moment-timezone/builds/moment-timezone-with-data.min.js',
           //'public/vendor/moment-duration-format/lib/moment-duration-format.js',
           //'public/vendor/handsontable/dist/jquery.handsontable.full.min.js',
           //'public/vendor/pdfmake/build/pdfmake.min.js',

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -136,7 +136,8 @@ class TaskController extends BaseController
             'method' => 'POST',
             'url' => 'tasks',
             'title' => trans('texts.new_task'),
-            'minuteOffset' => Utils::getTiemstampOffset(),
+            'timezone' => Auth::user()->account->timezone->name,
+            'datetimeFormat' => Auth::user()->account->datetime_format->format_moment_sec
         ];
 
         $data = array_merge($data, self::getViewModel());
@@ -186,7 +187,8 @@ class TaskController extends BaseController
             'title' => trans('texts.edit_task'),
             'duration' => $task->is_running ? $task->getCurrentDuration() : $task->getDuration(),
             'actions' => $actions,
-            'minuteOffset' => Utils::getTiemstampOffset(),
+            'timezone' => Auth::user()->account->timezone->name,
+            'datetimeFormat' => Auth::user()->account->datetime_format->format_moment_sec
         ];
 
         $data = array_merge($data, self::getViewModel());

--- a/bower.json
+++ b/bower.json
@@ -25,5 +25,8 @@
   },
   "resolutions": {
     "jquery": "~1.11"
+  },
+  "devDependencies": {
+    "moment-timezone": "~0.4.0"
   }
 }

--- a/database/migrations/2015_08_13_084041_add_formats_to_datetime_formats_table.php
+++ b/database/migrations/2015_08_13_084041_add_formats_to_datetime_formats_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddFormatsToDatetimeFormatsTable extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('datetime_formats', function(Blueprint $t)
+		{
+            $t->string('format_sec');
+            $t->string('format_moment');
+            $t->string('format_moment_sec');
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('datetime_formats', function(Blueprint $t)
+		{
+            $t->dropColumn('format_sec');
+            $t->dropColumn('format_moment');
+            $t->dropColumn('format_moment_sec');
+		});
+	}
+
+}

--- a/database/seeds/PaymentLibrariesSeeder.php
+++ b/database/seeds/PaymentLibrariesSeeder.php
@@ -109,6 +109,7 @@ class PaymentLibrariesSeeder extends Seeder
             ['format' => 'D M j, Y', 'picker_format' => 'D MM d, yyyy', 'label' => 'Mon March 10, 2013'],
             ['format' => 'Y-M-d', 'picker_format' => 'yyyy-M-dd', 'label' => '2013-03-10'],
             ['format' => 'd/m/Y', 'picker_format' => 'dd/mm/yyyy', 'label' => '20/03/2013'],
+            ['format' => 'd.m.Y', 'picker_format' => 'dd.mm.yyyy', 'label' => '20.03.2013']
         ];
         
         foreach ($formats as $format) {
@@ -121,15 +122,76 @@ class PaymentLibrariesSeeder extends Seeder
     private function createDatetimeFormats() {
 
         $formats = [
-            ['format' => 'd/M/Y g:i a', 'label' => '10/Mar/2013'],
-            ['format' => 'd-M-Yk g:i a', 'label' => '10-Mar-2013'],
-            ['format' => 'd/F/Y g:i a', 'label' => '10/March/2013'],
-            ['format' => 'd-F-Y g:i a', 'label' => '10-March-2013'],
-            ['format' => 'M j, Y g:i a', 'label' => 'Mar 10, 2013 6:15 pm'],
-            ['format' => 'F j, Y g:i a', 'label' => 'March 10, 2013 6:15 pm'],
-            ['format' => 'D M jS, Y g:ia', 'label' => 'Mon March 10th, 2013 6:15 pm'],
-            ['format' => 'Y-M-d g:i a', 'label' => '2013-03-10 6:15 pm'],
-            ['format' => 'd/m/Y g:i a', 'label' => '20/03/2013 6:15 pm'],
+            [
+                'format' => 'd/M/Y g:i a',
+                'format_sec' => 'd/M/Y g:i:s a',
+                'format_moment' => 'DD/MMM/YYYY h:mm a',
+                'format_moment_sec' => 'DD/MMM/YYYY h:mm:ss a',
+                'label' => '10/Mar/2013'
+            ],
+            [
+                'format' => 'd-M-Yk g:i a',
+                'format_sec' => 'd-M-Yk g:i:s a',
+                'format_moment' => 'DD-MMM-YYYY h:mm a',
+                'format_moment_sec' => 'DD-MMM-YYYY h:mm:ss a',
+                'label' => '10-Mar-2013'
+            ],
+            [
+                'format' => 'd/F/Y g:i a',
+                'format_sec' => 'd/F/Y g:i:s a',
+                'format_moment' => 'DD/MMMM/YYYY h:mm a',
+                'format_moment_sec' => 'DD/MMMM/YYYY h:mm:ss a',
+                'label' => '10/March/2013'
+            ],
+            [
+                'format' => 'd-F-Y g:i a',
+                'format_sec' => 'd-F-Y g:i:s a',
+                'format_moment' => 'DD-MMMM-YYYY h:mm a',
+                'format_moment_sec' => 'DD-MMMM-YYYY h:mm:ss a',
+                'label' => '10-March-2013'
+            ],
+            [
+                'format' => 'M j, Y g:i a',
+                'format_sec' => 'M j, Y g:i:s a',
+                'format_moment' => 'MMM D, YYYY h:mm a',
+                'format_moment_sec' => 'MMM D, YYYY h:mm:ss a',
+                'label' => 'Mar 10, 2013 6:15 pm'
+            ],
+            [
+                'format' => 'F j, Y g:i a',
+                'format_sec' => 'F j, Y g:i:s a',
+                'format_moment' => 'MMMM D, YYYY h:mm a',
+                'format_moment_sec' => 'MMMM D, YYYY h:mm:ss a',
+                'label' => 'March 10, 2013 6:15 pm'
+            ],
+            [
+                'format' => 'D M jS, Y g:ia',
+                'format_sec' => 'D M jS, Y g:i:sa',
+                'format_moment' => 'ddd MMM Do, YYYY h:mma',
+                'format_moment_sec' => 'ddd MMM Do, YYYY h:mm:ssa',
+                'label' => 'Mon March 10th, 2013 6:15 pm'
+            ],
+            [
+                'format' => 'Y-M-d g:i a',
+                'format_sec' => 'Y-M-d g:i:s a',
+                'format_moment' => 'YYYY-MMM-DD h:mm a',
+                'format_moment_sec' => 'YYYY-MMM-DD h:mm:ss a',
+                'label' => '2013-03-10 6:15 pm'
+            ],
+            [
+                'format' => 'd/m/Y g:i a',
+                'format_sec' => 'd/m/Y g:i:s a',
+                'format_moment' => 'DD/MM/YYYY h:mm a',
+                'format_moment_sec' => 'DD/MM/YYYY h:mm:ss a',
+                'label' => '20/03/2013 6:15 pm'
+            ],
+            [
+                'format' => 'd.m.Y H:i',
+                'format_sec' => 'd.m.Y H:i:s',
+                'format_moment' => 'DD.MM.YYYY HH:mm',
+                'format_moment_sec' => 'DD.MM.YYYY HH:mm:ss',
+                'label' => '20.03.2013 18:15'
+            ]
         ];
         
         foreach ($formats as $format) {

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -202,6 +202,10 @@
 
     function TimeModel(data) {
         var self = this;
+
+        var dateTimeFormat = '{{ $datetimeFormat }}';
+        var timezone = '{{ $timezone }}';
+
         self.startTime = ko.observable(0);
         self.endTime = ko.observable(0);
         self.duration = ko.observable(0);
@@ -220,25 +224,25 @@
 
         self.startTime.pretty = ko.computed({
             read: function() {                
-                return self.startTime() ? moment.unix(self.startTime()).utcOffset({{ $minuteOffset }}).format('MMM D YYYY h:mm:ss a') : '';    
+                return self.startTime() ? moment.unix(self.startTime()).tz(timezone).format(dateTimeFormat) : '';    
             }, 
             write: function(data) {
-                self.startTime(moment(data, 'MMM D YYYY h:mm:ss a').utcOffset({{ $minuteOffset }}).unix());
+                self.startTime(moment(data, dateTimeFormat).tz(timezone).unix());
             }
         });
 
         self.endTime.pretty = ko.computed({
             read: function() {
-                return self.endTime() ? moment.unix(self.endTime()).utcOffset({{ $minuteOffset }}).format('MMM D YYYY h:mm:ss a') : '';
+                return self.endTime() ? moment.unix(self.endTime()).tz(timezone).format(dateTimeFormat) : '';
             }, 
             write: function(data) {
-                self.endTime(moment(data, 'MMM D YYYY h:mm:ss a').utcOffset({{ $minuteOffset }}).unix());
+                self.endTime(moment(data, dateTimeFormat).tz(timezone).unix());
             }
         });
 
         self.setNow = function() {
-            self.startTime(moment().utcOffset({{ $minuteOffset }}).unix());
-            self.endTime(moment().utcOffset({{ $minuteOffset }}).unix());            
+            self.startTime(moment.tz(timezone).unix());
+            self.endTime(moment.tz(timezone).unix());
         }
 
         self.duration.pretty = ko.computed(function() {


### PR DESCRIPTION
I noticed a small bug when trying to create a time log entry for February. The hours constantly jumps to +1 hour on every change to the start/end input field.

The culprit seems to be the hard-coded $minutesOffset, which doesn't accommodate to a changed DST. By using moment-timezone, JS can correctly validate and correct the entered time and date. Worked like a charm in my tests.

Oh yeah, I translated all php datetime formats to a momentjs-usable one as well.

BTW, first github pull request for me! :o)