### PR TITLE
Updated german translation

### DIFF
--- a/resources/lang/de/texts.php
+++ b/resources/lang/de/texts.php
@@ -312,13 +312,13 @@ return array(
 
   'pro_plan_product' => 'Pro Plan',
   'pro_plan_description' => 'Jahresmitgliedschaft beim Invoice Ninja Pro Plan.',
-  'pro_plan_success' => 'Danke, dass du Invoice Ninja\'s Pro gewählt hast!<p/>&nbsp;<br/>
+  'pro_plan_success' => 'Danke, dass Sie Invoice Ninja\'s Pro gewählt haben!<p/>&nbsp;<br/>
                           <b>Nächste Schritte</b>Eine bezahlbare Rechnung wurde an die Mailadresse,
-                          welche mit deinem Account verbunden ist, geschickt. Um alle der umfangreichen 
-                          Pro Funktionen freizuschalten, folge bitte den Anweisungen in der Rechnung um ein Jahr
+                          welche mit Ihrem Account verbunden ist, geschickt. Um alle der umfangreichen 
+                          Pro Funktionen freizuschalten, folgen Sie bitte den Anweisungen in der Rechnung um ein Jahr
                           die Pro Funktionen zu nutzen.
-                          Du findest die Rechnung nicht? Du benötigst weitere Hilfe? Wir helfen gerne
-                          -- schick uns doch eine Email an contact@invoice-ninja.com',
+                          Sie finden die Rechnung nicht? Sie benötigen weitere Hilfe? Wir helfen gerne
+                          -- schicken Sie uns doch eine Email an contact@invoice-ninja.com',
 
   'unsaved_changes' => 'Es liegen ungespeicherte Änderungen vor',
   'custom_fields' => 'Benutzerdefinierte Felder',
@@ -463,7 +463,7 @@ return array(
   'sent' => 'gesendet',
   
   'vat_number' => 'USt-IdNr.',
-  'timesheets' => 'Timesheets',
+  'timesheets' => 'Zeittabellen',
 
   'payment_title' => 'Geben Sie Ihre Rechnungsadresse und Ihre Kreditkarteninformationen ein',
   'payment_cvv' => '*Dies ist die 3-4-stellige Nummer auf der Rückseite Ihrer Kreditkarte',
@@ -514,7 +514,7 @@ return array(
   'approve' => 'Zustimmen',
 
   'token_billing_type_id' => 'Token Billing',
-  'token_billing_help' => 'Ermöglicht dir, Kreditkarten mit Ihrem Gateway zu speichern und diese zu einem späteren Zeitpunkt zu belasten.',
+  'token_billing_help' => 'Ermöglicht Ihnen, Kreditkarten mit Ihrem Gateway zu speichern und diese zu einem späteren Zeitpunkt zu belasten.',
   'token_billing_1' => 'Deaktiviert',
   'token_billing_2' => 'Opt-in - Kontrollkästchen wird angezeigt ist aber nicht ausgewählt',
   'token_billing_3' => 'Opt-out - Kontrollkästchen wird angezeigt und ist ausgewählt',

--- a/resources/lang/de/texts.php
+++ b/resources/lang/de/texts.php
@@ -96,6 +96,7 @@ return array(
   'import' => 'Importieren',
   'download' => 'Downloaden',
   'cancel' => 'Abbrechen',
+  'close' => 'Schließen',
   'provide_email' => 'Bitte gib eine gültige E-Mail-Adresse an',
   'powered_by' => 'Powered by',
   'no_items' => 'Keine Objekte',
@@ -254,6 +255,7 @@ return array(
   'confirmation_subject' => 'InvoiceNinja Kontobestätigung',
   'confirmation_header' => 'Kontobestätigung',
   'confirmation_message' => 'Bitte klicke auf den folgenden Link um dein Konto zu bestätigen.',
+  'invoice_subject' => 'Neue Rechnung :invoice von :account',
   'invoice_message' => 'Um Ihre Rechnung über :amount einzusehen, klicken Sie bitte auf den folgenden Link:',
   'payment_subject' => 'Zahlungseingang',
   'payment_message' => 'Vielen Dank für Ihre Zahlung von :amount.',
@@ -271,6 +273,7 @@ return array(
   'reset_password' => 'Du kannst dein Passwort zurücksetzen, indem du auf den folgenden Link klickst:',
   'reset_password_footer' => 'Wenn du das Zurücksetzen des Passworts nicht beantragt hast, benachrichtige bitte unseren Support: ' . CONTACT_EMAIL,
 
+  
   // Payment page
   'secure_payment' => 'Sichere Zahlung',
   'card_number' => 'Kartennummer',
@@ -305,13 +308,17 @@ return array(
   'success_message' => 'Du hast dich erfolgreich registriert. Bitte besuche den Link in deiner Bestätigungsmail um deine E-Mail-Adresse zu verifizieren.',
   'erase_data' => 'Diese Aktion wird deine Daten dauerhaft löschen.',
   'password' => 'Passwort',
-  'invoice_subject' => 'Neue Rechnung :invoice von :account',
   'close' => 'Schließen',
 
   'pro_plan_product' => 'Pro Plan',
   'pro_plan_description' => 'Jahresmitgliedschaft beim Invoice Ninja Pro Plan.',
-  'pro_plan_success' => 'Danke für den Beitritt! Sobald die Rechnung bezahlt wurde, beginnt deine Pro Plan Mitgliedschaft.',
-  'pro_plan_success' => 'Danke für den Beitritt! Sobald die Rechnung bezahlt wurde,Beim Auswählen eines Produktes werden beginnt deine Pro Plan Mitgliedschaft.',
+  'pro_plan_success' => 'Danke, dass du Invoice Ninja\'s Pro gewählt hast!<p/>&nbsp;<br/>
+                          <b>Nächste Schritte</b>Eine bezahlbare Rechnung wurde an die Mailadresse,
+                          welche mit deinem Account verbunden ist, geschickt. Um alle der umfangreichen 
+                          Pro Funktionen freizuschalten, folge bitte den Anweisungen in der Rechnung um ein Jahr
+                          die Pro Funktionen zu nutzen.
+                          Du findest die Rechnung nicht? Du benötigst weitere Hilfe? Wir helfen gerne
+                          -- schick uns doch eine Email an contact@invoice-ninja.com',
 
   'unsaved_changes' => 'Es liegen ungespeicherte Änderungen vor',
   'custom_fields' => 'Benutzerdefinierte Felder',
@@ -320,6 +327,7 @@ return array(
   'field_label' => 'Feldbezeichnung',
   'field_value' => 'Feldwert',
   'edit' => 'Bearbeiten',
+  'set_name' => 'Den Firmennamen setzen',
   'view_as_recipient' => 'Als Empfänger betrachten',
 
   // product management
@@ -401,7 +409,7 @@ return array(
 
   'charge_taxes' => 'Steuern erheben',
   'user_management' => 'Benutzerverwaltung',
-  'add_user' => 'Add User',
+  'add_user' => 'Benutzer hinzufügen',
   'send_invite' => 'Einladung senden',
   'sent_invite' => 'Einladung erfolgreich gesendet',
   'updated_user' => 'Benutzer erfolgreich aktualisiert',
@@ -452,15 +460,15 @@ return array(
   'more_designs_self_host_text' => '',
   'buy' => 'Kaufen',
   'bought_designs' => 'Die zusätzliche Rechnungsvorlagen wurden erfolgreich hinzugefügt',
-
   'sent' => 'gesendet',
+  
+  'vat_number' => 'USt-IdNr.',
   'timesheets' => 'Timesheets',
 
   'payment_title' => 'Geben Sie Ihre Rechnungsadresse und Ihre Kreditkarteninformationen ein',
   'payment_cvv' => '*Dies ist die 3-4-stellige Nummer auf der Rückseite Ihrer Kreditkarte',
   'payment_footer1' => '*Die Rechnungsadresse muss mit der Adresse der Kreditkarte übereinstimmen.',
   'payment_footer2' => '*Bitte drücken Sie nur einmal auf "Jetzt bezahlen" - die  Verarbeitung der Transaktion kann bis zu einer Minute dauern.',
-  'vat_number' => 'USt-IdNr.',
 
   'id_number' => 'ID-Nummer',
   'white_label_link' => 'Branding entfernen',
@@ -506,7 +514,7 @@ return array(
   'approve' => 'Zustimmen',
 
   'token_billing_type_id' => 'Token Billing',
-  'token_billing_help' => 'Enables you to store credit cards with your gateway, and charge them at a later date.',
+  'token_billing_help' => 'Ermöglicht dir, Kreditkarten mit Ihrem Gateway zu speichern und diese zu einem späteren Zeitpunkt zu belasten.',
   'token_billing_1' => 'Deaktiviert',
   'token_billing_2' => 'Opt-in - Kontrollkästchen wird angezeigt ist aber nicht ausgewählt',
   'token_billing_3' => 'Opt-out - Kontrollkästchen wird angezeigt und ist ausgewählt',
@@ -578,7 +586,7 @@ return array(
   'resend_confirmation' => 'Bestätigungsmail erneut senden',
   'confirmation_resent' => 'Bestätigungsemail wurde erneut gesendet',
 
-  'gateway_help_42' => ':link to sign up for BitPay.<br/>Note: use a Legacy API Key, not an API token.',
+  'gateway_help_42' => ':link zum Registrieren auf BitPay.<br/>Hinweis: benutze einen Legacy API Key, keinen API token.',
   'payment_type_credit_card' => 'Kreditkarte',
   'payment_type_paypal' => 'PayPal',
   'payment_type_bitcoin' => 'Bitcoin',
@@ -595,7 +603,7 @@ return array(
   'duplicate_post' => 'Achtung: Die vorherige Seite wurde zweimal abgeschickt. Das zweite Abschicken wurde ignoriert.',
   'view_documentation' => 'Dokumentation anzeigen',
   'app_title' => 'Kostenlose Online Open-Source Rechnungsausstellung',
-  'app_description' => 'InvoiceNinja is a free, open-source solution for invoicing and billing customers. With Invoice Ninja, you can easily build and send beautiful invoices from any device that has access to the web. Your clients can print your invoices, download them as pdf files, and even pay you online from within the system.',
+  'app_description' => 'InvoiceNinja ist eine kostenlose, quelloffene Lösung für die Rechnungsstellung und Abrechnung von Kunden. Mit Invoice Ninja kannst du einfach schöne Rechnungen erstellen und verschicken, von jedem Gerät mit Internetzugang. Deine Kunden können die Rechnungen drucken, als PDF Datei herunterladen und sogar online im System bezahlen.',
 
   'rows' => 'Zeilen',
   'www' => 'www',
@@ -664,7 +672,7 @@ return array(
   'counter' => 'Zähler',
 
   'payment_type_dwolla' => 'Dwolla',
-  'gateway_help_43' => ':link to sign up for Dwolla.',
+  'gateway_help_43' => ':link zum Registrieren auf Dwolla.',
   'partial_value' => 'Muss größer als Null und kleiner als der Gesamtbetrag sein',
   'more_actions' => 'Weitere Aktionen',
 
@@ -739,8 +747,8 @@ return array(
   'recurring_invoice' => 'Wiederkehrende Rechnung',
   'recurring_too_soon' => 'Es ist zu früh, um die nächste wiederkehrende Rechnung zu erstellen',
   'created_by_invoice' => 'Erstellt durch :invoice',
-  'primary_user' => 'Primary User',
-  'help' => 'Help',
+  'primary_user' => 'Primärer Benutzer',
+  'help' => 'Hilfe',
   'customize_help' => '<p>We use <a href="http://pdfmake.org/" target="_blank">pdfmake</a> to define the invoice designs declaratively. The pdfmake <a href="http://pdfmake.org/playground.html" target="_blank">playground</a> provide\'s a great way to see the library in action.</p>
                         <p>You can access any invoice field by adding <code>Value</code> to the end. For example <code>$invoiceNumberValue</code> displays the invoice number.</p>
                         <p>To access a child property using dot notation. For example to show the client name you could use <code>$client.nameValue</code>.</p>


### PR DESCRIPTION
I've updated some translations for the german language.

I wasn't able to find strings für:
"Client approved quote Number"
"Admin updated invoice Number"
etc. (seen in the dashboard).

