### PR TITLE
Support SSL offloading

### DIFF
--- a/app/Http/Middleware/StartupCheck.php
+++ b/app/Http/Middleware/StartupCheck.php
@@ -25,6 +25,13 @@ class StartupCheck
      */
     public function handle($request, Closure $next)
     {
+        // Set up trusted X-Forwarded-Proto proxies
+        // TRUSTED_PROXIES accepts a comma delimited list of subnets
+        //
+        // TRUSTED_PROXIES='10.0.0.0/8,172.16.0.0/12,192.168.0.0/16'
+        if (isset($_ENV['TRUSTED_PROXIES'])) {
+            Request::setTrustedProxies(array_map('trim',explode(",",env('TRUSTED_PROXIES'))));
+        }
         // Ensure all request are over HTTPS in production
         if (App::environment() == ENV_PRODUCTION && !Request::secure()) {
             return Redirect::secure(Request::getRequestUri());


### PR DESCRIPTION
This adds a TRUSTED_PROXIES environment variable that enables the `Request::secure()` method to correctly and securely identify when a connection is passing through a SSL offloading frontend.