### PR TITLE
Allow zero-costs

### DIFF
--- a/app/Http/Controllers/InvoiceApiController.php
+++ b/app/Http/Controllers/InvoiceApiController.php
@@ -214,13 +214,13 @@ class InvoiceApiController extends Controller
         }
 
         // if only the product key is set we'll load the cost and notes
-        if ($item['product_key'] && (!$item['cost'] || !$item['notes'])) {
+        if ($item['product_key'] && (is_null($item['cost']) || is_null($item['notes']))) {
             $product = Product::findProductByKey($item['product_key']);
             if ($product) {
-                if (!$item['cost']) {
+                if (is_null($item['cost'])) {
                     $item['cost'] = $product->cost;
                 }
-                if (!$item['notes']) {
+                if (is_null($item['notes'])) {
                     $item['notes'] = $product->notes;
                 }
             }


### PR DESCRIPTION
Currently, the `parepareItem` method checks to see if the cost and notes evaluate to false. If so, it checks from the product list.

However, we need the ability to set cost to zero explicitly through the API. This allows a user to pass null, which will use the default. Otherwise, passing 0 will persist.